### PR TITLE
Fixing of hanging after "exit" in process which is linked to handler …

### DIFF
--- a/src/cowboy_stream_h.erl
+++ b/src/cowboy_stream_h.erl
@@ -101,6 +101,12 @@ info(StreamID, Exit = {'EXIT', Pid, {Reason, Stacktrace}}, State=#state{ref=Ref,
 		{error_response, 500, #{<<"content-length">> => <<"0">>}, <<>>},
 		{internal_error, Exit, 'Stream process crashed.'}
 	], State};
+info(StreamID, Exit = {'EXIT', Pid, Reason}, State=#state{ref=Ref, pid=Pid}) ->
+	report_crash(Ref, StreamID, Pid, Reason, []),
+	{[
+		{error_response, 500, #{<<"content-length">> => <<"0">>}, <<>>},
+		{internal_error, Exit, 'Stream process crashed.'}
+	], State};
 %% Request body, body buffered large enough or complete.
 info(_StreamID, {read_body, Ref, Length, _}, State=#state{pid=Pid,
 		read_body_is_fin=IsFin, read_body_buffer=Buffer, body_length=BodyLen})


### PR DESCRIPTION
Problem statement:

Request handler start linked process, which is finishing with `exit(Reason).` In such case the function [clause](https://github.com/alertlogic/cowboy/blob/ebde192661feb2e91616edc7cd9ebff116aeb40c/src/cowboy_stream_h.erl#L98)  for error handling will never be called and [default](https://github.com/alertlogic/cowboy/blob/ebde192661feb2e91616edc7cd9ebff116aeb40c/src/cowboy_stream_h.erl#L133) clause will be called instead. This causes hanging of cowboy.

The typical situation is starting `gen_server` from request handler. If `gen_server` returns `{stop, Reason}` after error in initialisation then `otp` calls `exit(Reason)` [internally](https://github.com/erlang/otp/blob/master/lib/stdlib/src/gen_server.erl#L353).

The solution:
New `info` clause for error without stacktrace.

@motobob please, take a look.